### PR TITLE
Map and bus timing clarity enhancements, theming improvements

### DIFF
--- a/assets/maps/map_style_dark.json
+++ b/assets/maps/map_style_dark.json
@@ -1,0 +1,161 @@
+[
+  {
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#242f3e"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#746855"
+      }
+    ]
+  },
+  {
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#242f3e"
+      }
+    ]
+  },
+  {
+    "featureType": "administrative.locality",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "poi",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#263c3f"
+      }
+    ]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#6b9a76"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#38414e"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry.stroke",
+    "stylers": [
+      {
+        "color": "#212a37"
+      }
+    ]
+  },
+  {
+    "featureType": "road",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#9ca5b3"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#746855"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry.stroke",
+    "stylers": [
+      {
+        "color": "#1f2835"
+      }
+    ]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#f3d19c"
+      }
+    ]
+  },
+  {
+    "featureType": "transit",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#2f3948"
+      }
+    ]
+  },
+  {
+    "featureType": "transit.station",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#d59563"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "geometry",
+    "stylers": [
+      {
+        "color": "#17263c"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.fill",
+    "stylers": [
+      {
+        "color": "#515c6d"
+      }
+    ]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.stroke",
+    "stylers": [
+      {
+        "color": "#17263c"
+      }
+    ]
+  }
+]

--- a/lib/routes/bus_service_page.dart
+++ b/lib/routes/bus_service_page.dart
@@ -7,9 +7,11 @@ import '../utils/bus_stop.dart';
 import 'bottom_sheet_page.dart';
 
 class BusServicePage extends BottomSheetPage {
-  BusServicePage(this.serviceNumber);
+  BusServicePage(this.serviceNumber) : focusedBusStop = null;
+  BusServicePage.withBusStop(this.serviceNumber, this.focusedBusStop);
 
   final String serviceNumber;
+  final BusStop focusedBusStop;
 
   @override
   State<StatefulWidget> createState() {
@@ -19,6 +21,8 @@ class BusServicePage extends BottomSheetPage {
 
 class _BusServicePageState extends BottomSheetPageState<BusServicePage> {
   BusService service;
+  int focusedDirection = 0;
+
   @override
   void initState() {
     super.initState();
@@ -28,6 +32,11 @@ class _BusServicePageState extends BottomSheetPageState<BusServicePage> {
   Future<void> initService() async {
     final BusService service = await getCachedBusServiceWithNumber(widget.serviceNumber);
     service.routes ??= await getCachedBusRoutes(service);
+    if (widget.focusedBusStop != null) {
+      if (service.directionCount > 1)
+        if (service.routes[1].busStops.contains(widget.focusedBusStop))
+          focusedDirection = 1;
+    }
     setState(() {
       this.service = service;
     });
@@ -45,6 +54,7 @@ class _BusServicePageState extends BottomSheetPageState<BusServicePage> {
 
   Widget _buildBody() {
     final TabController tabController = TabController(length: 2, vsync: this);
+    tabController.index = focusedDirection;
     return NestedScrollView(
       headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
         return <Widget>[
@@ -77,12 +87,27 @@ class _BusServicePageState extends BottomSheetPageState<BusServicePage> {
   }
 
   Widget _buildRouteBusStops(BusServiceRoute route) {
+    ScrollController controller;
+    if (widget.focusedBusStop != null) {
+      final double index = route.busStops.indexOf(widget.focusedBusStop).toDouble();
+      controller = ScrollController(initialScrollOffset: 56 * index);
+    }
+    else
+      controller = ScrollController();
     return MediaQuery.removePadding(
       context: context,
       removeTop: true,
       child: ListView.builder(
+        controller: controller,
         itemBuilder: (BuildContext context, int position) {
           final BusStop busStop = route.busStops[position];
+          if (busStop == widget.focusedBusStop)
+            return ListTile(
+              title: Text('${busStop.defaultName}', style: Theme.of(context).textTheme.title.copyWith(color: Theme.of(context).accentColor)),
+              subtitle: Text('${busStop.code}', style: Theme.of(context).textTheme.subtitle.copyWith(color: Theme.of(context).accentColor)),
+              leading: Text('${route.distances[position]}\nKM'),
+              onTap: () => showBusDetailSheet(busStop),
+            );
           return ListTile(
             title: Text('${busStop.defaultName}'),
             subtitle: Text('${busStop.code}'),

--- a/lib/routes/home_page.dart
+++ b/lib/routes/home_page.dart
@@ -3,10 +3,10 @@ import 'package:flutter/services.dart';
 import 'package:location/location.dart';
 
 import 'package:quick_actions/quick_actions.dart';
-import 'package:stops_sg/utils/location_utils.dart';
 
 import '../utils/bus_stop.dart';
 import '../utils/database_utils.dart';
+import '../utils/location_utils.dart';
 import '../widgets/bus_stop_overview_list.dart';
 import 'bottom_sheet_page.dart';
 import 'search_page.dart';
@@ -162,7 +162,7 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
     return FutureBuilder<Map<String, dynamic>>(
       future: _getNearestBusStops(),
       builder: (BuildContext context, AsyncSnapshot<Map<String, dynamic>> snapshot) {
-        return snapshot.hasData ? SliverToBoxAdapter(
+        return snapshot.hasData && snapshot.data['busStops'].length == 3 ? SliverToBoxAdapter(
           child: Container(
             height: 150,
             child: ListView.builder(

--- a/lib/routes/home_page.dart
+++ b/lib/routes/home_page.dart
@@ -27,14 +27,14 @@ class StopsApp extends StatelessWidget {
           accentColor: Colors.deepOrangeAccent,
           brightness: Brightness.light,
           textTheme: TextTheme(
-              display1: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, letterSpacing: 3, color: Colors.orangeAccent),
-              headline: TextStyle(fontWeight: FontWeight.w300, fontSize: 28),
+            display1: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, letterSpacing: 3, color: Colors.deepOrangeAccent),
+            headline: TextStyle(fontWeight: FontWeight.w300, fontSize: 28),
           ),
         ),
         darkTheme: ThemeData(
           fontFamily: 'Source Sans Pro',
           primarySwatch: Colors.blue,
-          toggleableActiveColor: Colors.deepOrangeAccent,
+          toggleableActiveColor: Colors.orangeAccent,
           accentColor: Colors.orangeAccent,
           brightness: Brightness.dark,
           textTheme: TextTheme(
@@ -109,7 +109,8 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
               Container(
                 padding: const EdgeInsets.only(
                     left: 16.0, top: 8.0, right: 8.0, bottom: 8.0),
-                child: Icon(Icons.search, color: Theme.of(context).hintColor)),
+                child: Icon(Icons.search, color: Theme.of(context).hintColor),
+              ),
               Expanded(
                 child: TextField(
                   enabled: false,
@@ -122,6 +123,11 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
                     Theme.of(context).hintColor),
                   ),
                 ),
+              ),
+              IconButton(
+                tooltip: 'Search on map',
+                icon: Icon(Icons.map, color: Theme.of(context).hintColor),
+                onPressed: _pushSearchRouteWithMap,
               ),
             ],
           ),
@@ -212,12 +218,18 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
   }
 
   Future<void> refreshLocation() async {
-    setState(() { });
+    setState(() {  });
   }
 
   void _pushSearchRoute() {
     busStopDetailSheet.rubberAnimationController.animateTo(to: busStopDetailSheet.rubberAnimationController.lowerBound);
     final Route<void> route = MaterialPageRoute<void>(builder: (BuildContext context) => SearchPage());
+    Navigator.push(context, route);
+  }
+
+  void _pushSearchRouteWithMap() {
+    busStopDetailSheet.rubberAnimationController.animateTo(to: busStopDetailSheet.rubberAnimationController.lowerBound);
+    final Route<void> route = MaterialPageRoute<void>(builder: (BuildContext context) => SearchPage(showMap: true));
     Navigator.push(context, route);
   }
 }

--- a/lib/routes/home_page.dart
+++ b/lib/routes/home_page.dart
@@ -4,6 +4,7 @@ import 'package:location/location.dart';
 
 import 'package:quick_actions/quick_actions.dart';
 
+import '../routes/settings_page.dart';
 import '../utils/bus_stop.dart';
 import '../utils/database_utils.dart';
 import '../utils/location_utils.dart';
@@ -11,49 +12,72 @@ import '../widgets/bus_stop_overview_list.dart';
 import 'bottom_sheet_page.dart';
 import 'search_page.dart';
 
-void main() => runApp(StopsApp());
+Future<void> main() async {
+  final ThemeMode themeMode = await getThemeMode();
+  runApp(StopsApp(themeMode));
+}
 
-class StopsApp extends StatelessWidget {
-  // This widget is the root of your application.
+class StopsApp extends StatefulWidget {
+  const StopsApp(this._themeMode);
+  final ThemeMode _themeMode;
+
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-        debugShowCheckedModeBanner: false,
-        title: 'Stops SG',
-        theme: ThemeData(
-          fontFamily: 'Source Sans Pro',
-          primarySwatch: Colors.blue,
-          toggleableActiveColor: Colors.deepOrangeAccent,
-          accentColor: Colors.deepOrangeAccent,
-          brightness: Brightness.light,
-          textTheme: TextTheme(
-            display1: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, letterSpacing: 3, color: Colors.deepOrangeAccent),
-            headline: TextStyle(fontWeight: FontWeight.w300, fontSize: 28),
-          ),
-        ),
-        darkTheme: ThemeData(
-          fontFamily: 'Source Sans Pro',
-          primarySwatch: Colors.blue,
-          toggleableActiveColor: Colors.orangeAccent,
-          accentColor: Colors.orangeAccent,
-          brightness: Brightness.dark,
-          textTheme: TextTheme(
-            display1: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, letterSpacing: 3, color: Colors.orangeAccent),
-            headline: TextStyle(fontWeight: FontWeight.w300, fontSize: 28),
-          ),
-        ),
-        home: HomePage(),
-    );
+  State createState() {
+    return StopsAppState(_themeMode);
   }
 
+  static StopsAppState of(BuildContext context) => context.ancestorStateOfType(const TypeMatcher<StopsAppState>());
+
   static SystemUiOverlayStyle overlayStyleWithBrightness(Brightness brightness) {
-    return SystemUiOverlayStyle(
+    final SystemUiOverlayStyle templateStyle = brightness == Brightness.light ? SystemUiOverlayStyle.dark : SystemUiOverlayStyle.light;
+    return templateStyle.copyWith(
       systemNavigationBarDividerColor: Colors.transparent,
       statusBarColor: Colors.transparent,
       statusBarIconBrightness: brightness == Brightness.light ? Brightness.dark : Brightness.light,
       statusBarBrightness: brightness,
       systemNavigationBarColor: brightness == Brightness.light ? ThemeData.light().canvasColor : ThemeData.dark().canvasColor,
       systemNavigationBarIconBrightness: brightness == Brightness.light ? Brightness.dark : Brightness.light,
+    );
+  }
+}
+
+class StopsAppState extends State<StopsApp> {
+  StopsAppState(this.themeMode);
+  ThemeMode themeMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'Stops SG',
+      themeMode: themeMode,
+      home: HomePage(),
+      theme: ThemeData(
+        fontFamily: 'Source Sans Pro',
+        primarySwatch: Colors.deepOrange,
+        toggleableActiveColor: Colors.deepOrangeAccent,
+        accentColor: Colors.deepOrangeAccent,
+        textSelectionColor: Colors.deepOrangeAccent,
+        textSelectionHandleColor: Colors.deepOrangeAccent,
+        brightness: Brightness.light,
+        textTheme: TextTheme(
+          display1: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, letterSpacing: 3, color: Colors.deepOrangeAccent),
+          headline: TextStyle(fontWeight: FontWeight.w300, fontSize: 28),
+        ),
+      ),
+      darkTheme: ThemeData(
+        fontFamily: 'Source Sans Pro',
+        primarySwatch: Colors.orange,
+        toggleableActiveColor: Colors.orangeAccent,
+        accentColor: Colors.orangeAccent,
+        textSelectionColor: Colors.deepOrangeAccent,
+        textSelectionHandleColor: Colors.orangeAccent,
+        brightness: Brightness.dark,
+        textTheme: TextTheme(
+          display1: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, letterSpacing: 3, color: Colors.orangeAccent),
+          headline: TextStyle(fontWeight: FontWeight.w300, fontSize: 28),
+        ),
+      ),
     );
   }
 }
@@ -82,8 +106,8 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    SystemChrome.setSystemUIOverlayStyle(StopsApp.overlayStyleWithBrightness(MediaQuery.of(context).platformBrightness));
     buildSheet(hasAppBar: false);
+    SystemChrome.setSystemUIOverlayStyle(StopsApp.overlayStyleWithBrightness(Theme.of(context).brightness));
 
     final Widget bottomSheetContainer = bottomSheet(child: _buildBody());
 
@@ -119,7 +143,7 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
                     contentPadding: const EdgeInsets.all(16.0),
                     border: InputBorder.none,
                     hintText: 'Search for bus stops and buses',
-                    hintStyle: TextStyle().copyWith(color:
+                    hintStyle: const TextStyle().copyWith(color:
                     Theme.of(context).hintColor),
                   ),
                 ),
@@ -128,6 +152,21 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
                 tooltip: 'Search on map',
                 icon: Icon(Icons.map, color: Theme.of(context).hintColor),
                 onPressed: _pushSearchRouteWithMap,
+              ),
+              PopupMenuButton<String>(
+                tooltip: 'Search on map',
+                icon: Icon(Icons.more_vert, color: Theme.of(context).hintColor),
+                onSelected: (String item) {
+                  if (item == 'Settings') {
+                    _pushSettingsRoute();
+                  }
+                },
+                itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
+                  const PopupMenuItem<String>(
+                    child: Text('Settings'),
+                    value: 'Settings',
+                  ),
+                ],
               ),
             ],
           ),
@@ -143,7 +182,7 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
         scrollDirection: Axis.vertical,
         slivers: <Widget>[
           SliverAppBar(
-            brightness: MediaQuery.of(context).platformBrightness,
+            brightness: Theme.of(context).brightness,
             titleSpacing: 8.0,
             title: Container(
               child: _buildSearchField(),
@@ -230,6 +269,11 @@ class _HomePageState extends BottomSheetPageState<HomePage> {
   void _pushSearchRouteWithMap() {
     busStopDetailSheet.rubberAnimationController.animateTo(to: busStopDetailSheet.rubberAnimationController.lowerBound);
     final Route<void> route = MaterialPageRoute<void>(builder: (BuildContext context) => SearchPage(showMap: true));
+    Navigator.push(context, route);
+  }
+
+  void _pushSettingsRoute() {
+    final Route<void> route = MaterialPageRoute<void>(builder: (BuildContext context) => SettingsPage());
     Navigator.push(context, route);
   }
 }

--- a/lib/routes/search_page.dart
+++ b/lib/routes/search_page.dart
@@ -171,7 +171,7 @@ class _SearchPageState extends BottomSheetPageState<SearchPage> {
 
   @override
   Widget build(BuildContext context) {
-    SystemChrome.setSystemUIOverlayStyle(StopsApp.overlayStyleWithBrightness(MediaQuery.of(context).platformBrightness));
+    SystemChrome.setSystemUIOverlayStyle(StopsApp.overlayStyleWithBrightness(Theme.of(context).brightness));
     buildSheet(hasAppBar: false);
     if (_query.isEmpty)
       _clearIconAnimationController.reverse();
@@ -360,7 +360,7 @@ class _SearchPageState extends BottomSheetPageState<SearchPage> {
           left: 0,
           right: 0,
           child: AppBar(
-            brightness: MediaQuery.of(context).platformBrightness,
+            brightness: Theme.of(context).brightness,
             backgroundColor: Colors.transparent,
             leading: null,
             automaticallyImplyLeading: false,

--- a/lib/routes/settings_page.dart
+++ b/lib/routes/settings_page.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:stops_sg/routes/home_page.dart';
+import 'package:stops_sg/utils/database_utils.dart';
+
+class SettingsPage extends StatefulWidget {
+  static const String _kThemeLabelSystem = 'System';
+  static const String _kThemeLabelLight = 'Light';
+  static const String _kThemeLabelDark = 'Dark';
+
+  @override
+  State createState() {
+    return SettingsPageState();
+  }
+}
+
+class SettingsPageState extends State<SettingsPage> {
+  ThemeMode _themeMode;
+
+  @override
+  void initState() {
+    super.initState();
+    getThemeMode().then((ThemeMode themeMode) {
+      setState(() {
+        _themeMode = themeMode;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: ListView(
+        children: <Widget>[
+          ListTile(
+            title: const Text('Theme'),
+            subtitle: Text(_getThemeLabel(_themeMode)),
+            leading: Icon(Icons.brush),
+            onTap: () {
+              showDialog<ThemeMode>(
+                context: context,
+                builder: (BuildContext context) {
+                  return AlertDialog(
+                    title: const Text('Choose theme'),
+                    contentPadding: const EdgeInsets.symmetric(vertical: 16.0),
+                    content: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        RadioListTile<ThemeMode>(
+                          title: Text(_getThemeLabel(ThemeMode.system)),
+                          value: ThemeMode.system,
+                          groupValue: _themeMode,
+                          onChanged: _onThemeModeChanged,
+                        ),
+                        RadioListTile<ThemeMode>(
+                          title: const Text(SettingsPage._kThemeLabelLight),
+                          value: ThemeMode.light,
+                          groupValue: _themeMode,
+                          onChanged: _onThemeModeChanged,
+                        ),
+                        RadioListTile<ThemeMode>(
+                          title: const Text(SettingsPage._kThemeLabelDark),
+                          value: ThemeMode.dark,
+                          groupValue: _themeMode,
+                          onChanged: _onThemeModeChanged,
+                        ),
+                      ],
+                    ),
+                  );
+                }
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getThemeLabel(ThemeMode themeMode) {
+    switch (themeMode) {
+      case ThemeMode.system:
+        final Brightness brightness = MediaQuery.of(context).platformBrightness;
+        final String brightnessLabel = brightness == Brightness.light ? SettingsPage._kThemeLabelLight : SettingsPage._kThemeLabelDark;
+        return '${SettingsPage._kThemeLabelSystem} ($brightnessLabel)';
+      case ThemeMode.light:
+        return SettingsPage._kThemeLabelLight;
+      case ThemeMode.dark:
+        return SettingsPage._kThemeLabelDark;
+      default:
+        return SettingsPage._kThemeLabelSystem;
+    }
+  }
+
+  Future<void> _onThemeModeChanged(ThemeMode themeMode) async {
+    await setThemeMode(themeMode);
+    Navigator.pop(context);
+    final StopsAppState appState = StopsApp.of(context);
+    appState.setState(() {
+      appState.themeMode = themeMode;
+    });
+    setState(() {
+      _themeMode = themeMode;
+    });
+  }
+}

--- a/lib/utils/database_utils.dart
+++ b/lib/utils/database_utils.dart
@@ -1,15 +1,16 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:latlong/latlong.dart' as latlong;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:stops_sg/utils/bus_api.dart';
-import 'package:stops_sg/utils/bus_route.dart';
-import 'package:stops_sg/utils/bus_utils.dart';
 
+import '../utils/bus_api.dart';
+import '../utils/bus_route.dart';
+import '../utils/bus_utils.dart';
 import 'bus_service.dart';
 import 'bus_stop.dart';
 
@@ -20,6 +21,7 @@ typedef BusFollowStatusListener = void Function(String stop, String bus, bool is
 /* Called when bus service is pinned/unpinned for a bus stop*/
 typedef BusPinStatusListener = void Function(String stop, String bus, bool isPinned);
 
+const String _themeModeKey = 'THEME_OPTION';
 const String _isBusFollowedKey = 'BUS_FOLLOW';
 const String _busServiceSkipNumberKey = 'BUS_SERVICE_SKIP';
 const String _searchHistoryKey = 'SEARCH_HISTORY';
@@ -60,6 +62,17 @@ Future<Database> _accessDatabase() async {
       },
       version: 1,
   );
+}
+
+Future<ThemeMode> getThemeMode() async {
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  final int themeModeIndex = prefs.containsKey(_themeModeKey) ? prefs.getInt(_themeModeKey) : ThemeMode.system.index;
+  return ThemeMode.values[themeModeIndex];
+}
+
+Future<void> setThemeMode(ThemeMode themeMode) async {
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  prefs.setInt(_themeModeKey, themeMode.index);
 }
 
 Future<Map<String, dynamic>> getNearestBusStops(double latitude, double longitude) async {

--- a/lib/widgets/bus_stop_detail_sheet.dart
+++ b/lib/widgets/bus_stop_detail_sheet.dart
@@ -616,9 +616,6 @@ class BusStopDetailSheetState extends State<BusStopDetailSheet>
                           textColor: Theme.of(context).accentColor,
                           onPressed: () {
                             textController.text = _busStop.defaultName;
-                            final String newName = textController.text;
-                            changeBusStopName(newName);
-                            Navigator.of(context).pop();
                           },
                           child: const Text('RESET', style: TextStyle(fontWeight: FontWeight.bold, letterSpacing: 1.1)),
                         ),

--- a/lib/widgets/bus_stop_detail_sheet.dart
+++ b/lib/widgets/bus_stop_detail_sheet.dart
@@ -10,6 +10,7 @@ import '../utils/bus_service_arrival_result.dart';
 import '../utils/bus_stop.dart';
 import '../utils/bus_utils.dart';
 import '../utils/database_utils.dart';
+import '../widgets/bus_stop_legend_card.dart';
 import '../widgets/bus_timing_row.dart';
 
 class BusStopDetailSheet extends StatefulWidget {
@@ -485,85 +486,9 @@ class BusStopDetailSheetState extends State<BusStopDetailSheet>
   }
 
   Widget _buildFooter(BuildContext context) {
-    final Brightness brightness = MediaQuery.of(context).platformBrightness;
     return Padding(
       padding: const EdgeInsets.all(16.0),
-      child: Container(
-        decoration: BoxDecoration(
-          border: Border.all(
-            color: Theme.of(context).dividerColor,
-          ),
-          borderRadius: const BorderRadius.all(
-            Radius.circular(16.0),
-          ),
-        ),
-        padding: const EdgeInsets.all(16.0),
-        child: Wrap(
-          direction: Axis.vertical,
-          spacing: 16,
-          children: <Widget>[
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Icon(Icons.info_outline, color: Theme.of(context).textTheme.display1.color),
-                Container(width: 8.0),
-                Text(
-                  'Legend',
-                  style: Theme.of(context).textTheme.display1
-                ),
-              ],
-            ),
-            Row(
-              children: <Widget>[
-                Container(
-                  width: 48,
-                  height: 16,
-                  margin: const EdgeInsets.only(right: 8.0),
-                  color: getBusLoadColor(BusLoad.low, brightness),
-                ),
-                const Text('Many seats'),
-              ],
-            ),
-            Row(
-              children: <Widget>[
-                Container(
-                  width: 48,
-                  height: 16,
-                  margin: const EdgeInsets.only(right: 8.0),
-                  color: getBusLoadColor(BusLoad.medium, brightness),
-                ),
-                const Text('Some seats'),
-              ],
-            ),
-            Row(
-              children: <Widget>[
-                Container(
-                  width: 48,
-                  height: 16,
-                  margin: const EdgeInsets.only(right: 8.0),
-                  color: getBusLoadColor(BusLoad.high, brightness),
-                ),
-                const Text('Few seats'),
-              ],
-            ),
-            Row(
-              children: <Widget>[
-                Container(
-                  width: 48,
-                  margin: const EdgeInsets.only(right: 8.0),
-                  child: Center(
-                    child: Text(
-                      getBusTypeVerbose(BusType.double),
-                      style: Theme.of(context).textTheme.title,
-                    ),
-                  ),
-                ),
-                const Text('Double-decker/Long'),
-              ],
-            ),
-          ],
-        ),
-      ),
+      child: BusStopLegendCard(),
     );
   }
 

--- a/lib/widgets/bus_stop_detail_sheet.dart
+++ b/lib/widgets/bus_stop_detail_sheet.dart
@@ -142,14 +142,17 @@ class BusStopDetailSheetState extends State<BusStopDetailSheet>
       ],
     );
 
-    return Material(
-      type: MaterialType.card,
-      borderRadius: const BorderRadius.only(
-        topLeft: Radius.circular(16.0),
-        topRight: Radius.circular(16.0),
+    return WillPopScope(
+      onWillPop: _onWillPop,
+      child: Material(
+        type: MaterialType.card,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(16.0),
+          topRight: Radius.circular(16.0),
+        ),
+        elevation: 16.0,
+        child: scrollView,
       ),
-      elevation: 16.0,
-      child: scrollView,
     );
   }
 
@@ -158,6 +161,22 @@ class BusStopDetailSheetState extends State<BusStopDetailSheet>
     timingListAnimationController.dispose();
     unregisterBusStopListener(_busStop, _busStopListener);
     super.dispose();
+  }
+
+  Future<bool> _onWillPop() async {
+    if (_isEditing) {
+      setState(() {
+        _isEditing = false;
+      });
+      return false;
+    }
+
+    if (widget.rubberAnimationController.value != 0) {
+      widget.rubberAnimationController.animateTo(to: 0);
+      return false;
+    }
+
+    return true;
   }
 
   Widget _buildHeader() {

--- a/lib/widgets/bus_stop_detail_sheet.dart
+++ b/lib/widgets/bus_stop_detail_sheet.dart
@@ -139,6 +139,7 @@ class BusStopDetailSheetState extends State<BusStopDetailSheet>
       children: <Widget>[
         _buildHeader(),
         _buildServiceList(),
+        _buildFooter(context),
       ],
     );
 
@@ -480,6 +481,89 @@ class BusStopDetailSheetState extends State<BusStopDetailSheet>
   Widget _messageBox(String text) {
     return Center(
         child: Text(text),
+    );
+  }
+
+  Widget _buildFooter(BuildContext context) {
+    final Brightness brightness = MediaQuery.of(context).platformBrightness;
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: Theme.of(context).dividerColor,
+          ),
+          borderRadius: const BorderRadius.all(
+            Radius.circular(16.0),
+          ),
+        ),
+        padding: const EdgeInsets.all(16.0),
+        child: Wrap(
+          direction: Axis.vertical,
+          spacing: 16,
+          children: <Widget>[
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Icon(Icons.info_outline, color: Theme.of(context).textTheme.display1.color),
+                Container(width: 8.0),
+                Text(
+                  'Legend',
+                  style: Theme.of(context).textTheme.display1
+                ),
+              ],
+            ),
+            Row(
+              children: <Widget>[
+                Container(
+                  width: 48,
+                  height: 16,
+                  margin: const EdgeInsets.only(right: 8.0),
+                  color: getBusLoadColor(BusLoad.low, brightness),
+                ),
+                const Text('Many seats'),
+              ],
+            ),
+            Row(
+              children: <Widget>[
+                Container(
+                  width: 48,
+                  height: 16,
+                  margin: const EdgeInsets.only(right: 8.0),
+                  color: getBusLoadColor(BusLoad.medium, brightness),
+                ),
+                const Text('Some seats'),
+              ],
+            ),
+            Row(
+              children: <Widget>[
+                Container(
+                  width: 48,
+                  height: 16,
+                  margin: const EdgeInsets.only(right: 8.0),
+                  color: getBusLoadColor(BusLoad.high, brightness),
+                ),
+                const Text('Few seats'),
+              ],
+            ),
+            Row(
+              children: <Widget>[
+                Container(
+                  width: 48,
+                  margin: const EdgeInsets.only(right: 8.0),
+                  child: Center(
+                    child: Text(
+                      getBusTypeVerbose(BusType.double),
+                      style: Theme.of(context).textTheme.title,
+                    ),
+                  ),
+                ),
+                const Text('Double-decker/Long'),
+              ],
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/widgets/bus_stop_legend_card.dart
+++ b/lib/widgets/bus_stop_legend_card.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../utils/bus_service_arrival_result.dart';
+import '../utils/bus_utils.dart';
+
+class BusStopLegendCard extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    final Brightness brightness = MediaQuery.of(context).platformBrightness;
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: Theme.of(context).dividerColor,
+        ),
+        borderRadius: const BorderRadius.all(
+          Radius.circular(16.0),
+        ),
+      ),
+      padding: const EdgeInsets.all(16.0),
+      child: Wrap(
+        direction: Axis.vertical,
+        spacing: 16,
+        children: <Widget>[
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.info_outline, color: Theme.of(context).textTheme.display1.color),
+              Container(width: 8.0),
+              Text(
+                  'Legend',
+                  style: Theme.of(context).textTheme.display1
+              ),
+            ],
+          ),
+          Row(
+            children: <Widget>[
+              Container(
+                width: 48,
+                height: 16,
+                margin: const EdgeInsets.only(right: 16.0),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8.0),
+                  color: getBusLoadColor(BusLoad.low, brightness),
+                ),
+              ),
+              const Text('Many seats'),
+            ],
+          ),
+          Row(
+            children: <Widget>[
+              Container(
+                width: 48,
+                height: 16,
+                margin: const EdgeInsets.only(right: 16.0),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8.0),
+                  color: getBusLoadColor(BusLoad.medium, brightness),
+                ),
+              ),
+              const Text('Some seats'),
+            ],
+          ),
+          Row(
+            children: <Widget>[
+              Container(
+                width: 48,
+                height: 16,
+                margin: const EdgeInsets.only(right: 16.0),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8.0),
+                  color: getBusLoadColor(BusLoad.high, brightness),
+                ),
+              ),
+              const Text('Few seats'),
+            ],
+          ),
+          Row(
+            children: <Widget>[
+              Container(
+                width: 48,
+                margin: const EdgeInsets.only(right: 16.0),
+                child: Center(
+                  child: Text(
+                    getBusTypeVerbose(BusType.double),
+                    style: Theme.of(context).textTheme.title,
+                  ),
+                ),
+              ),
+              const Text('Double-decker/Long'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/bus_stop_overview_item.dart
+++ b/lib/widgets/bus_stop_overview_item.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:stops_sg/widgets/bus_timing_row.dart';
 
 import '../routes/home_page.dart';
 import '../utils/bus_api.dart';
@@ -64,20 +65,28 @@ class BusStopOverviewItemState extends State<BusStopOverviewItem> {
           children: <Widget>[
             Padding(
               padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-              child: RichText(
-                text: TextSpan(
-                  text: '$name',
-                  children: <TextSpan>[
-                    TextSpan(
-                      text: ' · $code · $road',
-                      style: Theme.of(context)
-                          .textTheme
-                          .title
-                          .copyWith(color: Theme.of(context).hintColor),
-                    ),
+              child: Center(
+//                child: RichText(
+//                  text: TextSpan(
+//                    text: '$name',
+//                    children: <TextSpan>[
+//                      TextSpan(
+//                        text: ' · $code · $road',
+//                        style: Theme.of(context)
+//                            .textTheme
+//                            .title
+//                            .copyWith(color: Theme.of(context).hintColor),
+//                      ),
+//                    ],
+//                    style: Theme.of(context).textTheme.title,
+//                  ),
+//                ),
+                child: Column(
+                  children: <Widget>[
+                    Text(name, style: Theme.of(context).textTheme.title),
+                    Text('$code · $road', style: Theme.of(context).textTheme.subtitle.copyWith(color: Theme.of(context).hintColor)),
                   ],
-                  style: Theme.of(context).textTheme.title,
-                ),
+                )
               ),
             ),
             FutureBuilder<List<BusService>>(
@@ -115,25 +124,25 @@ class BusStopOverviewItemState extends State<BusStopOverviewItem> {
               continue done;
             done:
             case ConnectionState.done:
-              final List<BusServiceArrivalResult> buses = snapshot.data
+              final List<BusServiceArrivalResult> busArrivals = snapshot.data
                 .where((BusServiceArrivalResult result) => pinnedServices.contains(result.busService))
                 .toList(growable: false);
-              buses.sort((BusServiceArrivalResult a, BusServiceArrivalResult b) =>
+              busArrivals.sort((BusServiceArrivalResult a, BusServiceArrivalResult b) =>
                 compareBusNumber(a.busService.number, b.busService.number));
               _latestData = snapshot.data;
               return Padding(
                 padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-                child: buses.isNotEmpty ?
-                Wrap(
-                  spacing: 16.0,
-                  direction: Axis.horizontal,
-                  children: <Widget>[
-                    for (BusServiceArrivalResult arrivalResult in buses)
-                      BusTimingChip(
-                          serviceNumber: arrivalResult.busService.number,
-                          bus: arrivalResult.buses[0],
-                      ),
-                  ],
+                child: busArrivals.isNotEmpty ?
+                AbsorbPointer(
+                  absorbing: true,
+                  child: Wrap(
+                    spacing: 16.0,
+                    direction: Axis.horizontal,
+                    children: <Widget>[
+                      for (BusServiceArrivalResult arrivalResult in busArrivals)
+                        BusTimingRow.unfocusable(widget.busStop, arrivalResult.busService, arrivalResult)
+                    ],
+                  ),
                 ) : const Center(
                   child: Text(BusAPI.kNoPinnedBusesError),
                 ),

--- a/lib/widgets/bus_timing_row.dart
+++ b/lib/widgets/bus_timing_row.dart
@@ -197,7 +197,7 @@ class _BusTimingState extends State<BusTimingRow> with TickerProviderStateMixin 
   }
 
   void _pushBusServiceRoute(String serviceNumber) {
-    final Route<void> route = MaterialPageRoute<void>(builder: (BuildContext context) => BusServicePage(serviceNumber));
+    final Route<void> route = MaterialPageRoute<void>(builder: (BuildContext context) => BusServicePage.withBusStop(serviceNumber, widget.busStop));
     Navigator.push(context, route);
   }
 

--- a/lib/widgets/bus_timing_row.dart
+++ b/lib/widgets/bus_timing_row.dart
@@ -15,12 +15,15 @@ import '../widgets/bus_stop_detail_sheet.dart';
 
 class BusTimingRow extends StatefulWidget {
   const BusTimingRow(this.busStop, this.busService, this.arrivalResult, this.isEditing, {Key key})
-      : super(key: key);
+      : showNotificationButton = true, super(key: key);
+  const BusTimingRow.unfocusable(this.busStop, this.busService, this.arrivalResult, {Key key})
+      : isEditing = false, showNotificationButton = false, super(key: key);
 
   final BusStop busStop;
   final BusService busService;
   final BusServiceArrivalResult arrivalResult;
   final bool isEditing;
+  final bool showNotificationButton;
   static const double height = 56.0;
 
   bool get hasArrivals => arrivalResult != null;
@@ -105,7 +108,7 @@ class _BusTimingState extends State<BusTimingRow> with TickerProviderStateMixin 
                       ),
                   ],
                 ),
-                if (widget.hasArrivals)
+                if (widget.hasArrivals && widget.showNotificationButton)
                   _buildNotificationButton(),
               ],
             ),
@@ -127,9 +130,8 @@ class _BusTimingState extends State<BusTimingRow> with TickerProviderStateMixin 
       opacity: widget.isEditing ? 0 : 1,
       child: IconButton(
         tooltip: 'Notify me when the bus arrives',
-        icon: Icon(_isBusFollowed
-            ? Icons.notifications_active
-            : Icons.notifications_none),
+        icon: _isBusFollowed ? Icon(Icons.notifications_active)
+            : Icon(Icons.notifications_none, color: Theme.of(context).hintColor),
         onPressed: () {
           if (_isBusFollowed) {
             unfollowBus(stop: widget.busStop.code, bus: service.number);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stops_sg
 description: A Flutter application that displays live bus timings for bus stops in Singapore
 
-version: 0.3.0+8
+version: 0.4.0+8
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
@@ -57,3 +57,4 @@ flutter:
 
   assets:
     - assets/secrets.json
+    - assets/maps/map_style_dark.json

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stops_sg
 description: A Flutter application that displays live bus timings for bus stops in Singapore
 
-version: 0.4.0+8
+version: 0.4.1+9
 
 environment:
   sdk: ">=2.2.2 <3.0.0"

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,30 @@
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility that Flutter provides. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:stops_sg/routes/home_page.dart';
+
+void main() {
+//  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+//    // Build our app and trigger a frame.
+//    await tester.pumpWidget(StopsApp());
+//
+//    // Verify that our counter starts at 0.
+//    expect(find.text('0'), findsOneWidget);
+//    expect(find.text('1'), findsNothing);
+//
+//    // Tap the '+' icon and trigger a frame.
+//    await tester.tap(find.byIcon(Icons.add));
+//    await tester.pump();
+//
+//    // Verify that our counter has incremented.
+//    expect(find.text('0'), findsNothing);
+//    expect(find.text('1'), findsOneWidget);
+//  });
+}


### PR DESCRIPTION
# Notable changes
- Google Maps widget now has a proper spot in the app, greatly enhancing the usability of the map for locating a bus stop.
- Theme setting added as fallback for devices not supporting native dark mode
- Bus stop overviews in home page now show all bus timings per bus service
- Legend at the bottom of the bus stop info sheet
- Current bus stop will be focused when looking at one of the buses' routes from the bus stops bottom sheet

# Minor changes
- Notification bell icon change to hint color when inactive
- Fix text select cursor and selected text color
- Colored rectangles in Legend card are now rounded
  off
- Reset button for renaming bus stops will now not immediately commit the name change.
- Dark mode is also now supported on the map widget

# Bug fixes
- Search results now show the top result when the
  query is changed, as opposed to maintaining scroll
  position